### PR TITLE
Update interfaces.json

### DIFF
--- a/src/main/resources/interfaces.json
+++ b/src/main/resources/interfaces.json
@@ -18,7 +18,7 @@
     "io/wispforest/owo/ui/util/MatrixStackTransformer"
   ],
   "net/minecraft/core/component/DataComponentType\u0024Builder": [
-    "io/wispforest/owo/serialization/OwoComponentTypeBuilder<T;>"
+    "io/wispforest/owo/serialization/OwoComponentTypeBuilder<T>"
   ],
   "net/minecraft/world/item/Item\u0024Properties": [
     "io/wispforest/owo/itemgroup/OwoItemSettingsExtension"


### PR DESCRIPTION
The ";" isnt needed. It causes these errors:
```
*** Started working on sourcesWithNeoForge
 Compiling 5364 source files
 ERROR Line: 50, > or ',' expected in /net/minecraft/core/component/DataComponentType.java
 ERROR Line: 50, illegal start of type in /net/minecraft/core/component/DataComponentType.java
 ERROR Line: 50, initializers not allowed in interfaces in /net/minecraft/core/component/DataComponentType.java
 ERROR Line: 55, illegal start of expression in /net/minecraft/core/component/DataComponentType.java
 ERROR Line: 55, = expected in /net/minecraft/core/component/DataComponentType.java
 ERROR Line: 107, class, interface, enum, or record expected in /net/minecraft/core/component/DataComponentType.java
 ✓ Completed sourcesWithNeoForge in 2.51s
Total runtime: 8.79s

net.neoforged.neoform.runtime.graph.NodeExecutionException: Node action for recompile failed
	at net.neoforged.neoform.runtime.engine.NeoFormEngine.runNode(NeoFormEngine.java:458)
	at net.neoforged.neoform.runtime.engine.NeoFormEngine.lambda$getWaitCondition$3(NeoFormEngine.java:404)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
Caused by: java.io.IOException: Compilation failed
	at net.neoforged.neoform.runtime.actions.RecompileSourcesActionWithJDK.run(RecompileSourcesActionWithJDK.java:89)
	at net.neoforged.neoform.runtime.engine.NeoFormEngine.runNode(NeoFormEngine.java:447)
	... 4 more
```